### PR TITLE
fix: bug occuring if userContext or resourceContext is provided in request

### DIFF
--- a/authorizer/src/main/java/org/nifiopa/nifiopa/OpaAuthorizer.java
+++ b/authorizer/src/main/java/org/nifiopa/nifiopa/OpaAuthorizer.java
@@ -61,22 +61,12 @@ public class OpaAuthorizer implements Authorizer {
 					Map.of("isAccessAttempt", Boolean.toString(request.isAccessAttempt()),
 							"isAnonymous", Boolean.toString(request.isAnonymous())),
 					"userContext",
-					Map.of("", ""),
-
+					request.getUserContext() != null && !request.getUserContext().isEmpty() ? request.getUserContext() : Map.of("", ""),
 					"resourceContext",
-					Map.of("", ""));
-
-			if (request.getUserContext() != null && !request.getUserContext().isEmpty()) {
-				requestForm.put("userContext", request.getUserContext());
-			}
-
-			if (request.getResourceContext() != null && !request.getResourceContext().isEmpty()) {
-				requestForm.put("resourceContext", request.getResourceContext());
-			}
-
+					request.getResourceContext() != null && !request.getUserContext().isEmpty() ? request.getUserContext() : Map.of("", ""));
 		} catch (Exception e) {
 			logger.error(
-					MessageFormat.format("An error occured while trying to build the OPA-request: {0}", e.toString()));
+					"An error occured while trying to build the OPA-request", e);
 			return AuthorizationResult.denied("An error occured while trying to build the OPA-request");
 		}
 


### PR DESCRIPTION
This fixes a bug caused by trying to update an immutable entry of a map when `userContext` or `resourceContext` are provided in the request.

```
ERROR [NiFi Web Server-25] org.nifiopa.nifiopa.OpaAuthorizer An error occured while trying to build the OPA-request:
java.lang.UnsupportedOperationException: null
        at java.base/java.util.ImmutableCollections.uoe(Unknown Source)
        at java.base/java.util.ImmutableCollections$AbstractImmutableMap.put(Unknown Source)
        at org.nifiopa.nifiopa.OpaAuthorizer.authorize(OpaAuthorizer.java:70)
        [...]
```