### PR TITLE
Bump versions and removed unused dependencies

### DIFF
--- a/authorizer/pom.xml
+++ b/authorizer/pom.xml
@@ -17,9 +17,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
-    <nifi.version>1.27.0</nifi.version>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <nifi.version>2.3.0</nifi.version>
   </properties>
 
   <dependencies>
@@ -27,11 +27,6 @@
       <groupId>com.styra</groupId>
       <artifactId>opa</artifactId>
       <version>1.7.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.nifi</groupId>
-      <artifactId>nifi-api</artifactId>
-      <version>${nifi.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -51,12 +46,6 @@
     <dependency>
       <groupId>org.apache.nifi</groupId>
       <artifactId>nifi-framework-api</artifactId>
-      <version>${nifi.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.nifi</groupId>
-      <artifactId>nifi-logging-utils</artifactId>
       <version>${nifi.version}</version>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
- Start using Java 11 (last Java version supported by NiFi 1.x)
- Bump `nifi-framework-api` to `2.3.0`
- Remove unused dependencies